### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The primary motivation for these exercises is to explore the nexus of IPython, P
 - PE File Similarity Graph using Workbench
     - [Notebook Viewer](http://nbviewer.ipython.org/github/SuperCowPowers/workbench/blob/master/notebooks/PE_SimGraph.ipynb)
 
-#####Setup:
+##### Setup:
 
   * Required packages:
     * Brew/apt-get


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
